### PR TITLE
bump image version to 1.4.25-r4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/stacksmith-images/ubuntu:14.04-r9
 MAINTAINER Bitnami <containers@bitnami.com>
 
-ENV BITNAMI_IMAGE_VERSION=1.4.25-r3 \
+ENV BITNAMI_IMAGE_VERSION=1.4.25-r4 \
     BITNAMI_APP_NAME=memcached \
     BITNAMI_APP_USER=memcached
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ bats test.sh
 
 # Notable Changes
 
+## 1.4.25-r4
+
+- `MEMCACHED_USER` parameter has been renamed to `MEMCACHED_USERNAME`.
+
 ## 1.4.25-r0
 
 - The logs are always sent to the `stdout` and are no longer collected in the volume.


### PR DESCRIPTION
- `MEMCACHED_USER` parameter has been renamed to `MEMCACHED_USERNAME`.