### PR TITLE
fix typo in `saslpasswd2` command

### DIFF
--- a/1/debian-9/rootfs/libmemcached.sh
+++ b/1/debian-9/rootfs/libmemcached.sh
@@ -167,7 +167,7 @@ memcached_create_user() {
     local user="${1:?user is required}"
     local password="${2:?password is required}"
     debug "Creating memcached user '${user}'"
-    echo "${password}" | saslpasswd2 -f "${SASL_DB_FILE}" -a "memcached" -c "${user} -p"
+    echo "${password}" | saslpasswd2 -f "${SASL_DB_FILE}" -a "memcached" -c "${user}" -p
 }
 
 ########################

--- a/1/ol-7/rootfs/libmemcached.sh
+++ b/1/ol-7/rootfs/libmemcached.sh
@@ -167,7 +167,7 @@ memcached_create_user() {
     local user="${1:?user is required}"
     local password="${2:?password is required}"
     debug "Creating memcached user '${user}'"
-    echo "${password}" | saslpasswd2 -f "${SASL_DB_FILE}" -a "memcached" -c "${user} -p"
+    echo "${password}" | saslpasswd2 -f "${SASL_DB_FILE}" -a "memcached" -c "${user}" -p
 }
 
 ########################


### PR DESCRIPTION
fixes #62

**Description of the change**

A typo in the `saslpasswd2` command invocation resulted in broken auth configuration

**Benefits**

Fixes auth in memcached container

**Possible drawbacks**

No known drawbacks

**Applicable issues**

#62