### PR TITLE
(#74) Allow set max-item-size as environment variable

### DIFF
--- a/1/debian-10/rootfs/opt/bitnami/scripts/libmemcached.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/libmemcached.sh
@@ -54,6 +54,11 @@ memcached_validate() {
         print_validation_error "The variable MEMCACHED_THREADS must be positive integer"
     fi
 
+    # Memcached Threads validation
+    if [[ -n "${MEMCACHED_MAX_ITEM_SIZE}" ]] && ! is_positive_int "${MEMCACHED_MAX_ITEM_SIZE}"; then
+        print_validation_error "The variable MEMCACHED_MAX_ITEM_SIZE must be positive integer"
+    fi
+
     [[ "${error_code}" -eq 0 ]] || exit "$error_code"
 }
 

--- a/1/debian-10/rootfs/opt/bitnami/scripts/memcached-env.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/memcached-env.sh
@@ -30,6 +30,7 @@ memcached_env_vars=(
     MEMCACHED_CACHE_SIZE
     MEMCACHED_MAX_CONNECTIONS
     MEMCACHED_THREADS
+    MEMCACHED_MAX_ITEM_SIZE
 )
 for env_var in "${memcached_env_vars[@]}"; do
     file_env_var="${env_var}_FILE"
@@ -71,5 +72,6 @@ export MEMCACHED_MAX_TIMEOUT="${MEMCACHED_MAX_TIMEOUT:-5}"
 export MEMCACHED_CACHE_SIZE="${MEMCACHED_CACHE_SIZE:-}"
 export MEMCACHED_MAX_CONNECTIONS="${MEMCACHED_MAX_CONNECTIONS:-}"
 export MEMCACHED_THREADS="${MEMCACHED_THREADS:-}"
+export MEMCACHED_MAX_ITEM_SIZE="${MEMCACHED_MAX_ITEM_SIZE:-}"
 
 # Custom environment variables may be defined below

--- a/1/debian-10/rootfs/opt/bitnami/scripts/memcached/run.sh
+++ b/1/debian-10/rootfs/opt/bitnami/scripts/memcached/run.sh
@@ -24,6 +24,7 @@ args=("-u" "$MEMCACHED_DAEMON_USER" "-p" "$MEMCACHED_PORT_NUMBER" "-v")
 [[ -n "$MEMCACHED_CACHE_SIZE" ]] && args+=("-m" "$MEMCACHED_CACHE_SIZE")
 [[ -n "$MEMCACHED_MAX_CONNECTIONS" ]] && args+=("-c" "$MEMCACHED_MAX_CONNECTIONS")
 [[ -n "$MEMCACHED_THREADS" ]] && args+=("-t" "$MEMCACHED_THREADS")
+[[ -n "$MEMCACHED_MAX_ITEM_SIZE" ]] && args+=("-I" "$MEMCACHED_MAX_ITEM_SIZE")
 # Extra flags
 read -r -a extra_flags <<< "$MEMCACHED_EXTRA_FLAGS"
 [[ "${#extra_flags[@]}" -gt 0 ]] && args+=("${extra_flags[@]}")

--- a/README.md
+++ b/README.md
@@ -201,6 +201,25 @@ services:
   ...
 ```
 
+### Specify max item size (slab size)
+
+By default, the Bitnami Memcached container will not specify any max item size and will start with Memcached defaults (1048576 ~ 1 megabyte). You can specify a different value with the `MEMCACHED_MAX_ITEM_SIZE` environment variable. Only numeric values are accepted - use `8388608` instead of `8m`
+
+```console
+$ docker run --name memcached -e MEMCACHED_MAX_ITEM_SIZE=8388608 bitnami/memcached:latest
+```
+
+or by modifying the [`docker-compose.yml`](https://github.com/bitnami/bitnami-docker-memcached/blob/master/docker-compose.yml) file present in this repository:
+
+```yaml
+services:
+  memcached:
+  ...
+    environment:
+      - MEMCACHED_MAX_ITEM_SIZE=8388608
+  ...
+```
+
 ### Creating the Memcached admin user
 
 Authentication on the Memcached server is disabled by default. To enable authentication, specify the password for the Memcached admin user using the `MEMCACHED_PASSWORD` environment variable (or in the content of the file specified in `MEMCACHED_PASSWORD_FILE`).


### PR DESCRIPTION
**Description of the change**

Allow set `max-item-size` from environment variable

**Benefits**

Adjust `max-item-size` config property - default is 1MB, we need eg. 8MB for out app.

**Possible drawbacks**

none

**Applicable issues**

```
MemcachePool::set(): Server memcache.testing.svc.cluster.local (tcp 11211, udp 0) failed with: SERVER_ERROR object too large for cache (3)
```

**Additional information**

none
